### PR TITLE
Make the Chapel library copy command in util/test_python.bash more general

### DIFF
--- a/util/test_python.bash
+++ b/util/test_python.bash
@@ -36,7 +36,7 @@ log_info "Running pych --check"
 pych --check
 
 # Copying pyChapel libchpl dependencies
-cp $CHPL_HOME/lib/linux64*/* ~/virtualenv/python2.7.8/share/pych/lib/
+cp $CHPL_HOME/lib/linux64*/* $VIRTUAL_ENV/share/pych/lib/
 
 log_info "Moving to: ${TST_DIR}"
 cd $TST_DIR


### PR DESCRIPTION
By using the environment variable $VIRTUAL_ENV instead of a hard-coded path, we
can more easily utilize the same script for our nightly testing and the Travis
build.
