### PR TITLE
Fix off-by-one error in bfile fibonacci example.

### DIFF
--- a/docs/source/examples/bfiles/chapel/bfile.fib.chpl
+++ b/docs/source/examples/bfiles/chapel/bfile.fib.chpl
@@ -3,7 +3,7 @@ var x = 0;
 var y = 1;
 var z = 1;
 
-for i in 0..n {
+for 1..n {
     x = y;
     y = z;
     z = x + y;


### PR DESCRIPTION
Running examples/chapel.bfile.fib.py produced the output 89 as the 10th
fibonacci number, which is not correct.  That is the 11th fibonacci number.
The error arose from using 0 to n as the traversal (n+1 numbers), instead of 1
to n (n numbers).  While I was there, I removed the unnecessary traversal
variable i, since for loops can function without storing their iteration if it
isn't used by the body.