### PR TITLE
Use correct file name

### DIFF
--- a/docs/source/examples/chapel.sfile.hellolib.ename.py
+++ b/docs/source/examples/chapel.sfile.hellolib.ename.py
@@ -1,6 +1,6 @@
 from pych.extern import Chapel
 
-@Chapel(ename="hello_caller", sfile="chapel.hellolib.exported.chpl")
+@Chapel(ename="hello_caller", sfile="hellolib.exported.chpl")
 def hello_world():
     return None
 

--- a/docs/source/examples/chapel.sfile.hellolib.py
+++ b/docs/source/examples/chapel.sfile.hellolib.py
@@ -1,6 +1,6 @@
 from pych.extern import Chapel
 
-@Chapel(sfile="chapel.hellolib.exported.chpl")
+@Chapel(sfile="hellolib.exported.chpl")
 def hello_caller():
     return None
 


### PR DESCRIPTION
The two examples, chapel.sfile.hellolib.py and chapel.sfile.hellolib.ename.py,
were trying to access a sfile by the name of chapel.hellolib.exported.chpl when
the file was actually named hellolib.exported.chpl.  For consistency with the
other bfile and sfile names, I changed the python files rather than the name of
the file itself.