### PR TITLE
Fix broken doc build.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@ import os
 # copied from module/setup.py
 # This is hacky, but it means the following variables can be defined for
 # later use.
-with open('../../module/pych/version.py', 'r') as fp:
+with open(os.path.abspath('../../module/pych/version.py'), 'r') as fp:
     version_py_content = fp.read()
 APP_NAME = None
 APP_VERSION = None

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,8 @@ import sys
 import os
 
 # copied from module/setup.py
-# This is hacky, but it means install_requires can be defined below.
+# This is hacky, but it means the following variables can be defined for
+# later use.
 with open('../../module/pych/version.py', 'r') as fp:
     version_py_content = fp.read()
 APP_NAME = None

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,18 @@
 
 import sys
 import os
-from pych.version import APP_NAME, APP_VERSION
+
+# copied from module/setup.py
+# This is hacky, but it means install_requires can be defined below.
+with open('../../module/pych/version.py', 'r') as fp:
+    version_py_content = fp.read()
+APP_NAME = None
+APP_VERSION = None
+for line in version_py_content.splitlines():
+    if line.startswith('APP_NAME'):
+        APP_NAME = line.split("'", 2)[1].strip()
+    elif line.startswith('APP_VERSION'):
+        APP_VERSION = line.split("'", 2)[1].strip()
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/module/setup.py
+++ b/module/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 from distutils.command.install_data import install_data
 import pprint
 import glob
-import os
+import os.path
 
 # This is hacky, but it means install_requires can be defined below.
 with open(os.path.abspath('pych/version.py'), 'r') as fp:

--- a/module/setup.py
+++ b/module/setup.py
@@ -3,9 +3,10 @@ from distutils.core import setup
 from distutils.command.install_data import install_data
 import pprint
 import glob
+import os
 
 # This is hacky, but it means install_requires can be defined below.
-with open('pych/version.py', 'r') as fp:
+with open(os.path.abspath('pych/version.py'), 'r') as fp:
     version_py_content = fp.read()
 APP_NAME = None
 APP_VERSION = None


### PR DESCRIPTION
Read the Docs wasn't able to find the version.py module, so we altered its
usage in docs/source/conf.py.  Change is based on Thomas's similar change to
module/setup.py