### PR TITLE
Allow Travis to fail when the result of the py.test run fails

### DIFF
--- a/util/test_python.bash
+++ b/util/test_python.bash
@@ -44,5 +44,10 @@ cd $REPO_ROOT
 log_info "Running py.test over $TST_DIR and doc examples"
 py.test --verbose --junitxml=$REPO_ROOT/python-results.xml $TST_DIR docs/source/examples/
 
+passedPytest=$?
+
 log_info "Running pych --testing..."
 pych --testing
+
+passedPych=$?
+exit $passedPytest | $passedPych

--- a/util/test_python.bash
+++ b/util/test_python.bash
@@ -50,4 +50,4 @@ log_info "Running pych --testing..."
 pych --testing
 
 passedPych=$?
-exit $passedPytest | $passedPych
+exit $(( $passedPytest || $passedPych ))

--- a/util/test_python.bash
+++ b/util/test_python.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
 # Run the python unittests for code in docs/source/examples/.
+set -e
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
@@ -44,10 +45,5 @@ cd $REPO_ROOT
 log_info "Running py.test over $TST_DIR and doc examples"
 py.test --verbose --junitxml=$REPO_ROOT/python-results.xml $TST_DIR docs/source/examples/
 
-passedPytest=$?
-
 log_info "Running pych --testing..."
 pych --testing
-
-passedPych=$?
-exit $(( $passedPytest || $passedPych ))


### PR DESCRIPTION
Previously, Travis would report that the script passed when the py.test run
failed but the pych --testing run passed because the pych run happened last.
This allows Travis to tell us something went wrong in the first case.