### PR TITLE
Fix output dependent tests

### DIFF
--- a/docs/source/examples/test_begin.py
+++ b/docs/source/examples/test_begin.py
@@ -31,9 +31,10 @@ if __name__ == '__main__':
 
 import testcase
 # contains the general testing method, which allows us to gather output
+import os.path
 
 def test_begin():
-    out = testcase.runpy('test_begin.py')
+    out = testcase.runpy(os.path.realpath(__file__))
     # The first time this test is run, it may contain output notifying that
     # a temporary file has been created.  The important part is that this
     # expected output follows it (enabling the test to work for all runs, as

--- a/docs/source/examples/test_begin.py
+++ b/docs/source/examples/test_begin.py
@@ -15,37 +15,43 @@ def ex_begin_noret():
 @Chapel()
 def ex_begin():
     """
-    writeln("Starting!");
-    begin writeln("#1 line.");
-    begin writeln("#2 line.");
-    begin writeln("#3 line.");
-    begin writeln("#4 line.");
-    begin writeln("#5 line.");
+    writeln("Starting part2!");
+    begin writeln("#6 line.");
+    begin writeln("#7 line.");
+    begin writeln("#8 line.");
+    begin writeln("#9 line.");
+    begin writeln("#10 line.");
     return 0;
     """
     return int
 
-
-def test_begin_noret(capfd):
+if __name__ == '__main__':
     ex_begin_noret()
-    out, err = capfd.readouterr()
-    # ensure starts with correct statements
-    assert out.startswith('Starting!\n');
-    # ensure contains all of the remainder
-    assert '#1 line.\n' in out
-    assert '#2 line.\n' in out
-    assert '#3 line.\n' in out
-    assert '#4 line.\n' in out
-    assert '#5 line.\n' in out
-
-def test_begin_ret(capfd):
     ex_begin()
-    out, err = capfd.readouterr()
-    # ensure starts with correct statements
-    assert out.startswith('Starting!\n');
+
+import testcase
+# contains the general testing method, which allows us to gather output
+
+def test_begin():
+    out = testcase.runpy('test_begin.py')
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created.  The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run)  But that means
+    # we can't use out.startswith
+
+    # ensure starts and ends with correct statements
+    startLoc = out.find('Starting!\n')
+    assert startLoc >= 0
+    # While we can't ensure that all of the first function's output has occurred
+    # before the second function begins, we can ensure that their starting
+    # output is in order
+    secondStart = out.find('Starting part2!\n')
+    assert secondStart > startLoc
     # ensure contains all of the remainder
-    assert '#1 line.\n' in out
-    assert '#2 line.\n' in out
-    assert '#3 line.\n' in out
-    assert '#4 line.\n' in out
-    assert '#5 line.\n' in out
+    for i in xrange(1, 11):
+        lineLoc = out.find('#' + str(i) + ' line.\n')
+        assert lineLoc >= 0
+        assert lineLoc >= startLoc
+        if (i > 5):
+            assert lineLoc > secondStart

--- a/docs/source/examples/test_chapel_sfile.py
+++ b/docs/source/examples/test_chapel_sfile.py
@@ -10,9 +10,10 @@ if __name__ == "__main__":
 
 import testcase
 # contains the general testing method, which allows us to gather output
+import os.path
 
 def test_sfile():
-    out = testcase.runpy('test_chapel_sfile.py')
+    out = testcase.runpy(os.path.realpath(__file__))
     assert out.endswith('Hi Caller, I am Chapel, pleased to meet you.\n')
     # The first time this test is run, it may contain output notifying that
     # a temporary file has been created.  The important part is that this

--- a/docs/source/examples/test_chapel_sfile.py
+++ b/docs/source/examples/test_chapel_sfile.py
@@ -4,7 +4,17 @@ from pych.extern import Chapel
 def hello_caller():
     return None
 
-def test_sfile(capfd):
+if __name__ == "__main__":
     hello_caller()
-    out, err = capfd.readouterr()
-    assert out == 'Hi Caller, I am Chapel, pleased to meet you.\n'
+
+
+import testcase
+# contains the general testing method, which allows us to gather output
+
+def test_sfile():
+    out = testcase.runpy('test_chapel_sfile.py')
+    assert out.endswith('Hi Caller, I am Chapel, pleased to meet you.\n')
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created.  The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run)

--- a/docs/source/examples/test_cobegin.py
+++ b/docs/source/examples/test_cobegin.py
@@ -20,9 +20,10 @@ if __name__ == '__main__':
 
 import testcase
 # contains the general testing method, which allows us to gather output
+import os.path
 
 def test_cobegin():
-    out = testcase.runpy('test_cobegin.py')
+    out = testcase.runpy(os.path.realpath(__file__))
     # The first time this test is run, it may contain output notifying that
     # a temporary file has been created.  The important part is that this
     # expected output follows it (enabling the test to work for all runs, as

--- a/docs/source/examples/test_cobegin.py
+++ b/docs/source/examples/test_cobegin.py
@@ -15,15 +15,26 @@ def ex_cobegin5():
     """
     return None
 
-def test_cobegin(capfd):
+if __name__ == '__main__':
     ex_cobegin5()
-    out, err = capfd.readouterr()
+
+import testcase
+# contains the general testing method, which allows us to gather output
+
+def test_cobegin():
+    out = testcase.runpy('test_cobegin.py')
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created.  The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run)  But that means
+    # we can't use out.startswith
+
     # ensure starts and ends with correct statements
-    assert out.startswith('Starting!\n');
-    assert out.endswith('DONE!\n');
+    startLoc = out.find('Starting!\n')
+    assert startLoc >= 0
     # ensure contains all of the remainder
-    assert '#1 line.\n' in out
-    assert '#2 line.\n' in out
-    assert '#3 line.\n' in out
-    assert '#4 line.\n' in out
-    assert '#5 line.\n' in out
+    for i in xrange(1, 6):
+        lineLoc = out.find('#' + str(i) + ' line.\n')
+        assert lineLoc >= 0
+        assert lineLoc >= startLoc
+    assert out.endswith('DONE!\n')

--- a/docs/source/examples/test_for.py
+++ b/docs/source/examples/test_for.py
@@ -10,8 +10,14 @@ def ex_for(start=int, end=int):
     """
     return float
 
-def test_for(capfd):
+if __name__ == '__main__':
     ex_for(1, 1000)
-    out, err = capfd.readouterr()
-    for i in xrange(1, 1000):
-        assert 'This is ' + str(i) + '\n' in out
+
+
+import testcase
+# contains the general testing method, which allows us to gather output
+
+def test_for():
+    output = testcase.runpy('test_for.py');
+    for i in xrange(1, 1001):
+        assert 'This is ' + str(i) + '\n' in output

--- a/docs/source/examples/test_for.py
+++ b/docs/source/examples/test_for.py
@@ -16,8 +16,9 @@ if __name__ == '__main__':
 
 import testcase
 # contains the general testing method, which allows us to gather output
+import os.path
 
 def test_for():
-    output = testcase.runpy('test_for.py');
+    output = testcase.runpy(os.path.realpath(__file__));
     for i in xrange(1, 1001):
         assert 'This is ' + str(i) + '\n' in output

--- a/docs/source/examples/test_forall.py
+++ b/docs/source/examples/test_forall.py
@@ -16,8 +16,9 @@ if __name__ == '__main__':
 
 import testcase
 # contains the general testing method, which allows us to gather output
+import os.path
 
 def test_forall():
-    output = testcase.runpy('test_forall.py');
+    output = testcase.runpy(os.path.realpath(__file__))
     for i in xrange(1, 10001):
         assert 'This is ' + str(i) + '\n' in output

--- a/docs/source/examples/test_forall.py
+++ b/docs/source/examples/test_forall.py
@@ -10,8 +10,14 @@ def ex_forall(start=int, end=int):
     """
     return float
 
-def test_forall(capfd):
+if __name__ == '__main__':
     ex_forall(1, 10000)
-    out, err = capfd.readouterr()
-    for i in xrange(1, 10000):
-        assert 'This is ' + str(i) + '\n' in out
+
+
+import testcase
+# contains the general testing method, which allows us to gather output
+
+def test_forall():
+    output = testcase.runpy('test_forall.py');
+    for i in xrange(1, 10001):
+        assert 'This is ' + str(i) + '\n' in output

--- a/docs/source/examples/test_sync.py
+++ b/docs/source/examples/test_sync.py
@@ -15,15 +15,26 @@ def ex_sync():
     """
     return None
 
-def test_sync(capfd):
+if __name__ == '__main__':
     ex_sync()
-    out, err = capfd.readouterr()
+
+import testcase
+# contains the general testing method, which allows us to gather output
+
+def test_sync():
+    out = testcase.runpy('test_sync.py')
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created.  The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run)  But that means
+    # we can't use out.startswith
+
     # ensure starts and ends with correct statements
-    assert out.startswith('Starting!\n');
-    assert out.endswith('DONE!\n');
+    startLoc = out.find('Starting!\n')
+    assert startLoc >= 0
     # ensure contains all of the remainder
-    assert '#1 line.\n' in out
-    assert '#2 line.\n' in out
-    assert '#3 line.\n' in out
-    assert '#4 line.\n' in out
-    assert '#5 line.\n' in out
+    for i in xrange(1, 6):
+        lineLoc = out.find('#' + str(i) + ' line.\n')
+        assert lineLoc >= 0
+        assert lineLoc >= startLoc
+    assert out.endswith('DONE!\n')

--- a/docs/source/examples/test_sync.py
+++ b/docs/source/examples/test_sync.py
@@ -20,9 +20,10 @@ if __name__ == '__main__':
 
 import testcase
 # contains the general testing method, which allows us to gather output
+import os.path
 
 def test_sync():
-    out = testcase.runpy('test_sync.py')
+    out = testcase.runpy(os.path.realpath(__file__))
     # The first time this test is run, it may contain output notifying that
     # a temporary file has been created.  The important part is that this
     # expected output follows it (enabling the test to work for all runs, as

--- a/docs/source/examples/test_unusual_sfile_loc.py
+++ b/docs/source/examples/test_unusual_sfile_loc.py
@@ -25,6 +25,6 @@ import testcase
 # contains the general testing method, which allows us to gather output
 
 def test_unusual_sfile_loc():
-    out = testcase.runpy('test_unusual_sfile_loc.py')
+    out = testcase.runpy(os.path.realpath(__file__))
     assert 'Hello from mymodule\n' in out
     assert out.endswith('Hello from inline.\n')

--- a/docs/source/examples/test_unusual_sfile_loc.py
+++ b/docs/source/examples/test_unusual_sfile_loc.py
@@ -16,12 +16,15 @@ def hello_inline():
     """
     return None
 
-def test_unusual_sfile_loc(capfd):
+if __name__ == "__main__":
     hello_mymodule()
-    out, err = capfd.readouterr()
-    assert out == 'Hello from mymodule\n'
-
-def test_inline_output(capfd):
     hello_inline()
-    out, err = capfd.readouterr()
-    assert out == 'Hello from inline.\n'
+
+
+import testcase
+# contains the general testing method, which allows us to gather output
+
+def test_unusual_sfile_loc():
+    out = testcase.runpy('test_unusual_sfile_loc.py')
+    assert 'Hello from mymodule\n' in out
+    assert out.endswith('Hello from inline.\n')

--- a/docs/source/examples/testcase.py
+++ b/docs/source/examples/testcase.py
@@ -1,0 +1,19 @@
+import shlex
+import subprocess
+import sys
+
+# Copied and mildly modified from the testing setup in the related repository
+# chplforpyp-docs (also owned by us)
+
+def runpy(py_file, stdin=None):
+    """Run python script and return output.
+    
+    This is sort of like check_output, which was introduced in python 2.7.
+    """
+    cmd = [sys.executable]
+    cmd += shlex.split(py_file)
+    stdin_val = subprocess.PIPE if stdin else None
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                         stderr=subprocess.STDOUT, stdin=stdin_val)
+    output, _ = p.communicate(input=stdin)
+    return output


### PR DESCRIPTION
Py.test's capfd and capsys depend on certain circumstances to be true - namely,
that output is placed in a specific place.  With our Jenkins run, that is not
the case - either because of how python is set up to interact with Chapel or how
Chapel is set up, but all unique to Jenkins.  It doesn't really matter (though I am
curious).  It is still useful to have output tests, so instead of trying to depend on
py.test's built in functionality, implement our own method of capture (based in
part on the testing structure we built to ensure chplforpyp-docs examples work)

Because this method captures the initial message about creating a temporary
file for the materialized Chapel code (which only occurs the first time a test
is run), some of the previous assumptions about the output "starting with" a
particular sequence no longer hold.  However, we do want to make sure these
sequences precede the rest of the output, so the tests have been adjusted in
kind.