### PR TITLE
Add a test which fails

### DIFF
--- a/docs/source/examples/bfiles/chapel/material.file1.chpl
+++ b/docs/source/examples/bfiles/chapel/material.file1.chpl
@@ -1,0 +1,1 @@
+writeln("I'm file 1!");

--- a/docs/source/examples/bfiles/chapel/material.file2.chpl
+++ b/docs/source/examples/bfiles/chapel/material.file2.chpl
@@ -1,0 +1,1 @@
+writeln("I'm file 2!");

--- a/docs/source/examples/test_materialization_conflict_A.py
+++ b/docs/source/examples/test_materialization_conflict_A.py
@@ -1,3 +1,4 @@
+import pytest
 from pych.extern import Chapel
 
 @Chapel(bfile="material.file1.chpl")
@@ -13,21 +14,14 @@ import testcase
 # contains the general testing method, which allows us to gather output
 import os.path
 
+@pytest.mark.xfail
 def test_materialization_A():
     out = testcase.runpy(os.path.realpath(__file__))
     # The first time this test is run, it may contain output notifying that
     # a temporary file has been created.  The important part is that this
     # expected output follows it (enabling the test to work for all runs, as
     # the temporary file message won't occur in the second run)  But that means
-    # we can't use out.startswith
-    print out
+    # we can't use ==
 
-    # ensure contains both outputs
-    myLoc = out.find("I'm file 1!\n")
-    assert myLoc >= 0
-    otherLoc = out.find("I'm file 2!\n")
-    assert otherLoc >= 0
-    # I expect this assert to fail.
-
-    # ensure my output is first
-    assert otherLoc > myLoc
+    # ensure contains both outputs in the correct order
+    assert "I'm file 1!\nI'm file 2!\n" in out

--- a/docs/source/examples/test_materialization_conflict_A.py
+++ b/docs/source/examples/test_materialization_conflict_A.py
@@ -1,0 +1,33 @@
+from pych.extern import Chapel
+
+@Chapel(bfile="material.file1.chpl")
+def material():
+    return None
+
+if __name__ == '__main__':
+    material() # should be: I'm file 1!
+    import test_materialization_conflict_B
+    test_materialization_conflict_B.material() # should be: I'm file 2!
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+def test_materialization_A():
+    out = testcase.runpy(os.path.realpath(__file__))
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created.  The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run)  But that means
+    # we can't use out.startswith
+    print out
+
+    # ensure contains both outputs
+    myLoc = out.find("I'm file 1!\n")
+    assert myLoc >= 0
+    otherLoc = out.find("I'm file 2!\n")
+    assert otherLoc >= 0
+    # I expect this assert to fail.
+
+    # ensure my output is first
+    assert otherLoc > myLoc

--- a/docs/source/examples/test_materialization_conflict_B.py
+++ b/docs/source/examples/test_materialization_conflict_B.py
@@ -1,0 +1,33 @@
+from pych.extern import Chapel
+
+@Chapel(bfile="material.file2.chpl")
+def material():
+    return None
+
+if __name__ == '__main__':
+    material()
+    import test_materialization_conflict_A
+    test_materialization_conflict_A.material()
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+def test_materialization_A():
+    out = testcase.runpy(os.path.realpath(__file__))
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created.  The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run)  But that means
+    # we can't use out.startswith
+    print out
+
+    # ensure contains both outputs
+    myLoc = out.find("I'm file 2!\n")
+    assert myLoc >= 0
+    otherLoc = out.find("I'm file 1!\n")
+    assert otherLoc >= 0
+    # I expect this assert to fail.
+
+    # ensure my output is first
+    assert otherLoc > myLoc

--- a/docs/source/examples/test_materialization_conflict_B.py
+++ b/docs/source/examples/test_materialization_conflict_B.py
@@ -1,3 +1,4 @@
+import pytest
 from pych.extern import Chapel
 
 @Chapel(bfile="material.file2.chpl")
@@ -13,21 +14,14 @@ import testcase
 # contains the general testing method, which allows us to gather output
 import os.path
 
+@pytest.mark.xfail
 def test_materialization_B():
     out = testcase.runpy(os.path.realpath(__file__))
     # The first time this test is run, it may contain output notifying that
     # a temporary file has been created.  The important part is that this
     # expected output follows it (enabling the test to work for all runs, as
     # the temporary file message won't occur in the second run)  But that means
-    # we can't use out.startswith
-    print out
+    # we can't use ==
 
-    # ensure contains both outputs
-    myLoc = out.find("I'm file 2!\n")
-    assert myLoc >= 0
-    otherLoc = out.find("I'm file 1!\n")
-    assert otherLoc >= 0
-    # I expect this assert to fail.
-
-    # ensure my output is first
-    assert otherLoc > myLoc
+    # ensure contains both outputs in the correct order
+    assert "I'm file 2!\nI'm file 1!\n" in out

--- a/docs/source/examples/test_materialization_conflict_B.py
+++ b/docs/source/examples/test_materialization_conflict_B.py
@@ -13,7 +13,7 @@ import testcase
 # contains the general testing method, which allows us to gather output
 import os.path
 
-def test_materialization_A():
+def test_materialization_B():
     out = testcase.runpy(os.path.realpath(__file__))
     # The first time this test is run, it may contain output notifying that
     # a temporary file has been created.  The important part is that this


### PR DESCRIPTION
This circumstance was encountered through py.test but is more
reasonably captured in a single case.  When two modules that
are used in a single program try to access two separate
external functions that share a name, the first function accessed
will be used in both cases.  I think that the materialization of
functions (and use of cached materializations) should take into
account the source location of the external function, so that
if the current source and the previous source differ, both will be
accessed under the correct circumstances.

If we have support for accessing multiple modules in a Chapel file, it'd be nice
for the separate materialization to apply to functions in separate modules.
That will probably be tricky, though.