### PR TITLE
Add three tests of using arbitrary Chapel modules within export Chapel code

### DIFF
--- a/docs/source/examples/bfiles/chapel/arbitraryfile.chpl
+++ b/docs/source/examples/bfiles/chapel/arbitraryfile.chpl
@@ -1,0 +1,23 @@
+proc foo(x, y) {
+  return (x + y)* y;
+}
+
+proc bar() {
+  var res: [1..5] int = 14;
+  res[3] = 2;
+  writeln(res);
+  return res;
+}
+
+record whatev {
+  param num = 4;
+  type t = real(32);
+  var contents: t;
+}
+
+proc baz() {
+  var rec: whatev;
+  rec.contents = 3.0: real(32);
+  writeln(rec);
+  return rec;
+}

--- a/docs/source/examples/bfiles/chapel/user.chpl
+++ b/docs/source/examples/bfiles/chapel/user.chpl
@@ -1,0 +1,8 @@
+use arbitraryfile;
+
+writeln(foo(1, 2));
+// Should be 6
+writeln(bar());
+// Should be 14 14 3 14 14\n14 14 3 14 14\n
+writeln(baz());
+// Should be (num = 4, contents = 3.0)\n(num = 4, contents = 3.0)\n

--- a/docs/source/examples/sfiles/chapel/arbitraryfile.chpl
+++ b/docs/source/examples/sfiles/chapel/arbitraryfile.chpl
@@ -1,0 +1,23 @@
+proc foo(x, y) {
+  return (x + y)* y;
+}
+
+proc bar() {
+  var res: [1..5] int = 14;
+  res[3] = 2;
+  writeln(res);
+  return res;
+}
+
+record whatev {
+  param num = 4;
+  type t = real(32);
+  var contents: t;
+}
+
+proc baz() {
+  var rec: whatev;
+  rec.contents = 3.0: real(32);
+  writeln(rec);
+  return rec;
+}

--- a/docs/source/examples/sfiles/chapel/user.chpl
+++ b/docs/source/examples/sfiles/chapel/user.chpl
@@ -1,0 +1,11 @@
+export
+proc useArbitrary() {
+  use arbitraryfile;
+
+  writeln(foo(1, 2));
+  // Should be 6
+  writeln(bar());
+  // Should be 14 14 3 14 14\n14 14 3 14 14\n
+  writeln(baz());
+  // Should be (num = 4, contents = 3.0)\n(num = 4, contents = 3.0)\n
+}

--- a/docs/source/examples/test_arbitrary_chapel_use.py
+++ b/docs/source/examples/test_arbitrary_chapel_use.py
@@ -1,0 +1,19 @@
+import pytest
+from pych.extern import Chapel
+
+@Chapel(sfile="user.chpl")
+def useArbitrary():
+    return None
+
+
+if __name__ == "__main__":
+    useArbitrary()
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+@pytest.mark.xfail
+def test_using_other_chapel_code():
+    out = testcase.runpy(os.path.realpath(__file__))
+    assert out.endswith('6\n14 14 3 14 14\n14 14 3 14 14\n(num = 4, contents = 3.0)\n(num = 4, contents = 3.0)\n')

--- a/docs/source/examples/test_bfile_arbitrary_chapel.py
+++ b/docs/source/examples/test_bfile_arbitrary_chapel.py
@@ -1,0 +1,19 @@
+import pytest
+from pych.extern import Chapel
+
+@Chapel(bfile="user.chpl")
+def useArbitraryBfile():
+    return None
+
+
+if __name__ == "__main__":
+    useArbitraryBfile()
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+@pytest.mark.xfail
+def test_using_other_chapel_code():
+    out = testcase.runpy(os.path.realpath(__file__))
+    assert out.endswith('6\n14 14 3 14 14\n14 14 3 14 14\n(num = 4, contents = 3.0)\n(num = 4, contents = 3.0)\n')

--- a/docs/source/examples/test_inline_arbitrary_chapel.py
+++ b/docs/source/examples/test_inline_arbitrary_chapel.py
@@ -1,0 +1,30 @@
+import pytest
+from pych.extern import Chapel
+
+# Don't have a way to specify where the Chapel module arbitraryfile would live
+# The intention seems to be the addition of an argument lib to @Chapel
+@Chapel()
+def useArbitrary():
+    """
+    use arbitraryfile;
+
+    writeln(foo(1, 2));
+    // Should be 6
+    writeln(bar());
+    // Should be 14 14 3 14 14\n14 14 3 14 14\n
+    writeln(baz());
+    // Should be (num = 4, contents = 3.0)\n(num = 4, contents = 3.0)\n
+    """
+    return None
+
+if __name__ == "__main__":
+    useArbitrary()
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+@pytest.mark.xfail
+def test_using_other_chapel_code():
+    out = testcase.runpy(os.path.realpath(__file__))
+    assert out.endswith('6\n14 14 3 14 14\n14 14 3 14 14\n(num = 4, contents = 3.0)\n(num = 4, contents = 3.0)\n')


### PR DESCRIPTION
Unfortunately, right now we cannot include use statements that reference Chapel
code which is not present in the internal or standard modules in our exported
or inlined Chapel functions called from Python.  These tests attempt to do so
by placing the other Chapel file in question in the same sfile/bfile location as
the calling code.

Since Chapel module files such as Time have been used in other tests, I remain
hopeful that we can expand pyChapel to make use of specified locations to look
for further Chapel code - however, it is apparent that work needs to be done to
achieve this (I believe c.library.py demonstrates an in-progress attempt at this
functionality, for instance).