### PR TITLE
Add some tests to lock in behavior with exported functions.

### DIFF
--- a/docs/source/examples/sfiles/chapel/exported.and.array.chpl
+++ b/docs/source/examples/sfiles/chapel/exported.and.array.chpl
@@ -1,0 +1,15 @@
+export
+proc foo(x: int, y: int): int {
+  var res = bar(x, y);
+  return res + x;
+}
+
+proc bar(x, y) {
+  var arr: [0..1] int;
+  // This array type, at the time this test was written, was not supported in
+  // the type declaration of the function exported to be used with python.
+  // However, it appears to be fine when used by Chapel code.
+  arr[0] = x;
+  arr[1] = y;
+  return (arr[0] + arr[1])*(arr[0] - arr[1]);
+}

--- a/docs/source/examples/sfiles/chapel/exported.and.not.chpl
+++ b/docs/source/examples/sfiles/chapel/exported.and.not.chpl
@@ -1,0 +1,9 @@
+export
+proc foo(x: int, y: int): int {
+  var res = bar(x, y);
+  return res + x;
+}
+
+proc bar(x, y) {
+  return (x + y)*(x - y);
+}

--- a/docs/source/examples/test_use_nonexported.py
+++ b/docs/source/examples/test_use_nonexported.py
@@ -1,0 +1,15 @@
+from pych.extern import Chapel
+
+@Chapel(sfile="exported.and.not.chpl")
+def foo(x=int, y=int):
+    return int
+
+if __name__ == '__main__':
+    print foo(3, 5)
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+def test_sfile():
+    assert foo(3, 5) == -13

--- a/docs/source/examples/test_use_nonexported_array.py
+++ b/docs/source/examples/test_use_nonexported_array.py
@@ -1,0 +1,15 @@
+from pych.extern import Chapel
+
+@Chapel(sfile="exported.and.array.chpl")
+def foo(x=int, y=int):
+    return int
+
+if __name__ == '__main__':
+    print foo(3, 5)
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+def test_sfile():
+    assert foo(3, 5) == -13


### PR DESCRIPTION
Namely, that export functions can call other Chapel functions in the same file,
and that such called functions at least can make use of types not known to
pyChapel at this time.