### PR TITLE
Resolve pyChapel testing errors

### DIFF
--- a/docs/source/examples/bfiles/chapel/arbitraryfile.chpl
+++ b/docs/source/examples/bfiles/chapel/arbitraryfile.chpl
@@ -10,7 +10,6 @@ proc bar() {
 }
 
 record whatev {
-  param num = 4;
   type t = real(32);
   var contents: t;
 }

--- a/docs/source/examples/sfiles/chapel/arbitraryfile.chpl
+++ b/docs/source/examples/sfiles/chapel/arbitraryfile.chpl
@@ -10,7 +10,6 @@ proc bar() {
 }
 
 record whatev {
-  param num = 4;
   type t = real(32);
   var contents: t;
 }

--- a/docs/source/examples/test_arbitrary_chapel_use.py
+++ b/docs/source/examples/test_arbitrary_chapel_use.py
@@ -21,4 +21,4 @@ def test_using_other_chapel_code():
     the decorator argument "module_dirs"
     """
     out = testcase.runpy(os.path.realpath(__file__))
-    assert out.endswith('6\n14 14 3 14 14\n14 14 3 14 14\n(num = 4, contents = 3.0)\n(num = 4, contents = 3.0)\n')
+    assert out.endswith('6\n14 14 3 14 14\n14 14 3 14 14\n(contents = 3.0)\n(contents = 3.0)\n')

--- a/docs/source/examples/test_bfile_arbitrary_chapel.py
+++ b/docs/source/examples/test_bfile_arbitrary_chapel.py
@@ -21,4 +21,4 @@ def test_using_other_chapel_code():
     the decorator argument "module_dirs"
     """
     out = testcase.runpy(os.path.realpath(__file__))
-    assert out.endswith('6\n14 14 3 14 14\n14 14 3 14 14\n(num = 4, contents = 3.0)\n(num = 4, contents = 3.0)\n')
+    assert out.endswith('6\n14 14 3 14 14\n14 14 3 14 14\n(contents = 3.0)\n(contents = 3.0)\n')

--- a/docs/source/examples/test_inline_arbitrary_chapel.py
+++ b/docs/source/examples/test_inline_arbitrary_chapel.py
@@ -16,8 +16,8 @@ def useArbitrary():
     // Should be: 14 14 3 14 14
     // 14 14 3 14 14
     writeln(baz());
-    // Should be: (num = 4, contents = 3.0)
-    // (num = 4, contents = 3.0)
+    // Should be: (contents = 3.0)
+    // (contents = 3.0)
     """
     return None
 
@@ -34,4 +34,4 @@ def test_using_other_chapel_code():
     the decorator argument "module_dirs"
     """
     out = testcase.runpy(os.path.realpath(__file__))
-    assert out.endswith('6\n14 14 3 14 14\n14 14 3 14 14\n(num = 4, contents = 3.0)\n(num = 4, contents = 3.0)\n')
+    assert out.endswith('6\n14 14 3 14 14\n14 14 3 14 14\n(contents = 3.0)\n(contents = 3.0)\n')

--- a/docs/source/examples/test_use_and_name_conflict.py
+++ b/docs/source/examples/test_use_and_name_conflict.py
@@ -27,4 +27,4 @@ def test_using_other_chapel_code():
     the same name.
     """
     out = testcase.runpy(os.path.realpath(__file__))
-    assert out.endswith('6\n14 14 3 14 14\n14 14 3 14 14\n(num = 4, contents = 3.0)\n(num = 4, contents = 3.0)\n2\n')
+    assert out.endswith('6\n14 14 3 14 14\n14 14 3 14 14\n(contents = 3.0)\n(contents = 3.0)\n2\n')


### PR DESCRIPTION
These tests started failing in our nightly testing suite due to a long standing
bug that had been brought to the forefront by some clean up Michael did in the
Chapel compiler.  The bug is that the assignment operator for records that are
generic on multiple fields doesn't resolve, and the POD clean up looks for a
user-defined assignment overload (while determining if a type is POD or not)
by trying to resolve a call to it.  If the user hasn't defined an overload,
then the compiler runs into this error.  This problem goes away if the record
is only generic for one field, so I altered the type definition, since the extra field
wasn't necessary anyways.