### PR TITLE
Update expected error message in this test

### DIFF
--- a/docs/source/examples/test_no_depends_fails.py
+++ b/docs/source/examples/test_no_depends_fails.py
@@ -15,4 +15,4 @@ def test_using_multiple_modules():
     out = testcase.runpy(os.path.realpath(__file__))
     # Ensure that when a used module is nowhere near the exported function, we
     # get an error message to that effect.
-    assert "error: Cannot find module \'M1\'" in out
+    assert "error: Cannot find module or enum \'M1\'" in out


### PR DESCRIPTION
With the new ability to "use" enums, the error message for failing to find a
module had been updated to indicate that we didn't find a module or an enum,
making this test's expected output fail to match.  Update the expected error
message to reflect this new functionality.