### PR TITLE
Quick patch: Force matplotlib version to be less than 1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Sphinx
 sphinx_rtd_theme
 sphinxcontrib-bibtex
 numpy
-matplotlib
+matplotlib<1.5.0


### PR DESCRIPTION
Our testing system uses python 2.6 still, but the latest version of matplotlib
no longer supports that version of python.

We need to get later python support and update our testing system, but for now,
make sure we work in testing.