### PR TITLE
Fix config error on ubuntu machine

### DIFF
--- a/module/pych/configuration.py
+++ b/module/pych/configuration.py
@@ -31,7 +31,7 @@ class Configuration(object):
             config_path = []
             path = inspect.getmodule(self).__file__.split(os.sep)
             for directory in path:
-                if directory == "lib":
+                if directory == "lib" or directory == "local":
                     break
                 config_path.append(directory)
             config_path += [


### PR DESCRIPTION
We switched to a different test machine because that machine had python 2.7
installed on it, but this meant that the configuration file's relative path
used to find the pych.json file wasn't accurate.

This patch doesn't complete resolve that problem, it just delays it while I
think of a better solution.  Should allow testing to pass again.