### PR TITLE
Revert "Quick patch: Force matplotlib version to be less than 1.5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Sphinx
 sphinx_rtd_theme
 sphinxcontrib-bibtex
 numpy
-matplotlib<1.5.0
+matplotlib


### PR DESCRIPTION
This reverts commit 79c6f64a3b37679ffb81ff4cf44e12539b9f7274.

Since we bit the bullet and moved to a testing machine with python 2.7,
this requirement is no longer necessary.  We just don't support 2.6 now.
Which is a valid course, in our opinion.