### PR TITLE
Mark all functions that modify an array's `blk` with the required pragma

### DIFF
--- a/module/ext/src/extern.chpl
+++ b/module/ext/src/extern.chpl
@@ -15,6 +15,7 @@ module Pythonic {
         var data:_ddata(real);
     }
 
+    pragma "modifies array blk"
     proc pych_to_chpl(arr: pych_array) {
 
         var dom = {0..1, 0..4};

--- a/module/ext/src/ptrToArray.chpl
+++ b/module/ext/src/ptrToArray.chpl
@@ -32,6 +32,7 @@ proc lolo(spin: _ddata(int(64))) {
     return spin;
 }
 
+pragma "modifies array blk"
 proc convert(ref foo : _ddata(int), d, stride: d.rank*int, block: d.rank*int) {
   var ret = new DefaultRectangularArr(eltType=foo.eltType, rank=d.rank,
       idxType=d.idxType,     // index type of domain

--- a/module/templates/chapel/prefix.chpl
+++ b/module/templates/chapel/prefix.chpl
@@ -54,6 +54,7 @@ proc rangify(shape) where isTuple(shape) {
     }
 }
 
+pragma "modifies array blk"
 proc pych_to_chpl1D(arr: pych_array) {
     var dom = {0..(arr.shape(1):int(64)-1)};
 
@@ -98,6 +99,7 @@ proc pych_to_chpl1D(arr: pych_array) {
     return ret;
 }
 
+pragma "modifies array blk"
 proc pych_to_chpl2D(arr: pych_array) {
 
     var dom = {(...rangify(arr.shape))};


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/4510 added an optimization to remove
an inner `blk` multiply for cases where the compiler could prove it wasn't
needed. However, it's kind of a lame optimization (see the PR for why) and it
requires marking all functions that modify an array's blk field. Pychapel is
messing around with array internals (which it shouldn't really be doing IMO)
so we need to mark the functions that modify blk.