### PR TITLE
Fix pychapel after Chapel array memory management improvements

### DIFF
--- a/module/ext/src/extern.chpl
+++ b/module/ext/src/extern.chpl
@@ -72,7 +72,7 @@ module Pythonic {
         foo.data = _ddata_allocate(real, 10);
         
         var ret = pych_to_chpl(foo);
-        var arr = new _array(ret, ret);
+        var arr = _getArray(ret);
         arr = 4.0;
         arr += 1.0;
         writeln(arr);

--- a/module/ext/src/ptrToArray.chpl
+++ b/module/ext/src/ptrToArray.chpl
@@ -81,7 +81,7 @@ printDData();
 var ret = convert(ptr, {1..2, 1..5}, (1,1), (5,1));
 
 // the actual chapel array.
-var arr = new _array(ret, ret);
+var arr = _getArray(ret);
 writeln(arr);
 
 arr[1,1] = 11;

--- a/module/templates/chapel/convert.pych.1d.chpl
+++ b/module/templates/chapel/convert.pych.1d.chpl
@@ -1,2 +1,2 @@
 var %(aname)s__defaultRect = pych_to_chpl1D(%(aname)s_pych);
-var %(aname)s = _getArray(%(aname)s__defaultRect);
+var %(aname)s => _getArray(%(aname)s__defaultRect);

--- a/module/templates/chapel/convert.pych.1d.chpl
+++ b/module/templates/chapel/convert.pych.1d.chpl
@@ -1,2 +1,2 @@
 var %(aname)s__defaultRect = pych_to_chpl1D(%(aname)s_pych);
-var %(aname)s = new _array(%(aname)s__defaultRect, %(aname)s__defaultRect);
+var %(aname)s = _getArray(%(aname)s__defaultRect);

--- a/module/templates/chapel/prefix.chpl
+++ b/module/templates/chapel/prefix.chpl
@@ -70,6 +70,8 @@ proc pych_to_chpl1D(arr: pych_array) {
         noinit_data = true              // Prevent overwriting your data
     );     
    
+    dom._value.add_arr(ret);
+
     for i in 1..arr.nd {
         // TODO: Is this conversion from bytes to elements correct?
         //ret.str(i) = (arr.strides(i):int(64) / (arr.itemsize));
@@ -116,6 +118,8 @@ proc pych_to_chpl2D(arr: pych_array) {
         dom = dom._value,               // The underlying class implementation
         noinit_data = true              // Prevent overwriting your data
     );     
+
+    dom._value.add_arr(ret);
 
     // rank*int tuples
 


### PR DESCRIPTION
The PR for the array memory management improvements is here:
https://github.com/chapel-lang/chapel/pull/4762

The initial symptom was compilation failures from the Chapel compiler.

This PR updates pychapel to no longer use 'new _array' and instead use _getArray. Additionally, when creating a Chapel array that refers to a NumPy array, it uses the alias operator so that the array is not copied. Lastly, adjusted the pych_to_chpl1D method in order to add the returned array to the domain so that the domain will be freed with the array (instead of being freed when that function exits and causing core dumps).

Reviewed by @lydia-duncan - thanks!