### PR TITLE
Various updates due to Chapel repo improvements

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -50,12 +50,12 @@ Reload your environment, then build the compiler::
 
 After building the two files: "libchpl.a" and "main.o" library should be available here::
 
-  ~/chapel/lib/linux64.gnu.arch-native.loc-flat.comm-none.tasks-fifo.tmr-generic.mem-cstdlib.atomics-intrinsics.gmp-none.hwloc-none.re-none.wide-struct.fs-none/
+  ~/chapel/lib/linux64/gnu/arch-native/loc-flat/comm-none/tasks-fifo/tmr-generic/mem-cstdlib/atomics-intrinsics/gmp-none/hwloc-none/re-none/wide-struct/fs-none/
 
 Copy these to the "lib" library of pyChapel. Using a default install this can be
 done with the command::
 
-  cp ~/chapel/lib/linux64*/* /usr/local/share/pych/lib/
+  find ~/chapel/lib/ -depth -type f -exec bash -c 'cp $0 /usr/local/share/pych/lib/' {} \;
 
 After going through these steps the installation can be verified by running the
 "pych" command::

--- a/module/configs/pych.json
+++ b/module/configs/pych.json
@@ -82,7 +82,6 @@
                 "--fast",
                 "--library",
                 "--static",
-                "-snoRefCount",
                 "-searlyShiftData=false"
             ],
             "lflags": [

--- a/module/ext/src/ptrToArray.chpl
+++ b/module/ext/src/ptrToArray.chpl
@@ -1,10 +1,6 @@
 config const n = 10;
 const drange = 0..n-1;
 
-// NOTE: Compile with -snoRefCount for this to work correctly.
-// The 'convert' function doesn't set up the array to be
-// reference counted correctly.
-
 var ptr : _ddata(int) = _ddata_allocate(int, n);
 
 proc printDData() {

--- a/util/test_python.bash
+++ b/util/test_python.bash
@@ -37,7 +37,7 @@ log_info "Running pych --check"
 pych --check
 
 # Copying pyChapel libchpl dependencies
-cp $CHPL_HOME/lib/linux64*/* $VIRTUAL_ENV/share/pych/lib/
+find $CHPL_HOME/lib/ -depth -type f -exec bash -c 'cp $0  $VIRTUAL_ENV/share/pych/lib/' {} \;
 
 log_info "Moving to: ${REPO_ROOT}"
 cd $REPO_ROOT


### PR DESCRIPTION
Includes:
- Remove use of deprecated noRefCount flag from Chapel compilation
- Adjust for new build system

Remove use of deprecated noRefCount flag from Chapel compilation
---------------------------------------------------------------------------------------
This flag was removed in Chapel PR [4912,](https://github.com/chapel-lang/chapel/pull/4912)
as a clean up from it no longer being useful.  It was also no longer needed in
pyChapel, as the fix it was providing had been performed in another manner
after the array rework, so I removed the flag and the comment referencing
why it was used in the first place.

Verified that one of the failing tests now passes.  Travis verified full
testing.

Adjust for new build system
----------------------------------
With the build updates to the Chapel repository in
[Chapel PR 4913](https://github.com/chapel-lang/chapel/pull/4913), our
installation script for verifying the behavior of pyChapel was failing to find
the necessary library files.  Update the command used to be more
robust (if a bit more bash mystical, thanks StackOverflow!) and find the
files it should copy from within the $CHPL_HOME/lib directory.

Also update the generated documentation to tell the user how to find the
new location for these files

Verified that the command used worked locally, Travis verified the
script update is correct.