### PR TITLE
Prep for latest release

### DIFF
--- a/module/pych/version.py
+++ b/module/pych/version.py
@@ -2,4 +2,4 @@
     A container for pyChapel name and version.
 """
 APP_NAME = 'pyChapel'
-APP_VERSION = '0.1.16'
+APP_VERSION = '0.1.17'


### PR DESCRIPTION
Bump version number in prep for release with fixes for Chapel's build system
and the removal of the noRefCount flag.

Should've done this back in December.  Thankfully, we don't seem to need
more updates (that I can tell)