### PR TITLE
Revert "Mark all functions that modify an array's `blk` with the required pragma

### DIFF
--- a/module/ext/src/extern.chpl
+++ b/module/ext/src/extern.chpl
@@ -15,7 +15,6 @@ module Pythonic {
         var data:_ddata(real);
     }
 
-    pragma "modifies array blk"
     proc pych_to_chpl(arr: pych_array) {
 
         var dom = {0..1, 0..4};

--- a/module/ext/src/ptrToArray.chpl
+++ b/module/ext/src/ptrToArray.chpl
@@ -28,7 +28,6 @@ proc lolo(spin: _ddata(int(64))) {
     return spin;
 }
 
-pragma "modifies array blk"
 proc convert(ref foo : _ddata(int), d, stride: d.rank*int, block: d.rank*int) {
   var ret = new DefaultRectangularArr(eltType=foo.eltType, rank=d.rank,
       idxType=d.idxType,     // index type of domain

--- a/module/templates/chapel/prefix.chpl
+++ b/module/templates/chapel/prefix.chpl
@@ -54,7 +54,6 @@ proc rangify(shape) where isTuple(shape) {
     }
 }
 
-pragma "modifies array blk"
 proc pych_to_chpl1D(arr: pych_array) {
     var dom = {0..(arr.shape(1):int(64)-1)};
 
@@ -101,7 +100,6 @@ proc pych_to_chpl1D(arr: pych_array) {
     return ret;
 }
 
-pragma "modifies array blk"
 proc pych_to_chpl2D(arr: pych_array) {
 
     var dom = {(...rangify(arr.shape))};


### PR DESCRIPTION
This reverts commit 57ab950da22cc1d2eb18fbf1173af83c77393261.

Remove the "modifies array blk" pragma from pychapel. This pragma (and the
optimization it corresponded to) have been obsoleted by array-views. See
https://github.com/chapel-lang/chapel/pull/5548 for more info.