### PR TITLE
Avoid/fix failure for test after array views merge in the Chapel implementation

### DIFF
--- a/docs/source/examples/test_finance_chapel_numpy_flatten.py
+++ b/docs/source/examples/test_finance_chapel_numpy_flatten.py
@@ -10,8 +10,6 @@ import matplotlib.ticker as mticker
 import matplotlib.dates as mdates
 import numpy as np
 
-import pytest
-
 from pych.extern import Chapel
 
 elapsed = [time.time()]
@@ -56,6 +54,9 @@ def load_prices(filename):
         unpack=True,
         delimiter=',',
     )
+    date = date.flatten()
+    bid = bid.flatten()
+    ask = ask.flatten()
     voodoo = np.empty(date.shape)
 
     return date, bid, ask, voodoo
@@ -103,7 +104,6 @@ import testcase
 # contains the general testing method, which allows us to gather output
 import os
 
-@pytest.mark.xfail
 def test_example():
     filename = os.sep.join([
         os.path.dirname(os.path.realpath(__file__)), "aux", "GBPUSD1m.txt"

--- a/docs/source/examples/test_modify_array_argument_reals.py
+++ b/docs/source/examples/test_modify_array_argument_reals.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+import numpy as np
+
+from pych.extern import Chapel
+
+@Chapel()
+def printArray(arr=np.ndarray):
+    """
+    arr += 1;
+    writeln(arr);
+    """
+    return None
+
+if __name__ == "__main__":
+    arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    print arr
+    printArray(arr);
+    print arr
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+def test_modify_array_argument_reals():
+    out = testcase.runpy(os.path.realpath(__file__))
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created. The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run) But that means
+    # we can't use ==
+    assert out.endswith("[  2.   3.   4.   5.   6.   7.   8.   9.  10.  11.]\n");

--- a/docs/source/examples/test_modify_local_array_copy_reals.py
+++ b/docs/source/examples/test_modify_local_array_copy_reals.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+import numpy as np
+
+from pych.extern import Chapel
+
+@Chapel()
+def printArray(arr=np.ndarray):
+    """
+    var arrCopy = arr;
+    arrCopy += 1;
+    writeln(arrCopy);
+    """
+    return None
+
+if __name__ == "__main__":
+    arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    print arr
+    printArray(arr);
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+def test_modify_local_array_copy_reals():
+    out = testcase.runpy(os.path.realpath(__file__))
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created. The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run) But that means
+    # we can't use ==
+    assert out.endswith("2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0\n");

--- a/docs/source/examples/test_multiple_array_args_reals.py
+++ b/docs/source/examples/test_multiple_array_args_reals.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import numpy as np
+
+from pych.extern import Chapel
+
+@Chapel()
+def printArray(arr=np.ndarray, arr2 = np.ndarray):
+    """
+    var arrCopy = arr+arr2;
+    writeln(arrCopy);
+    """
+    return None
+
+if __name__ == "__main__":
+    arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    arr2 = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    print arr
+    print arr2
+    printArray(arr, arr2);
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+def test_multiple_array_args_reals():
+    out = testcase.runpy(os.path.realpath(__file__))
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created. The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run) But that means
+    # we can't use ==
+    assert out.endswith("2.0 4.0 6.0 8.0 10.0 12.0 14.0 16.0 18.0 20.0\n");

--- a/docs/source/examples/test_return_array_reals.py
+++ b/docs/source/examples/test_return_array_reals.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+import numpy as np
+
+import pytest
+
+from pych.extern import Chapel
+
+@Chapel()
+def printArray(arr=np.ndarray):
+    """
+    var arrCopy = arr;
+    arrCopy += 1;
+    writeln(arrCopy);
+    return arrCopy;
+    """
+    return np.ndarray
+
+if __name__ == "__main__":
+    arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    print arr
+    arr2 = printArray(arr);
+    print arr2
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+@pytest.mark.xfail
+def test_return_array_reals():
+    out = testcase.runpy(os.path.realpath(__file__))
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created. The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run) But that means
+    # we can't use ==
+    assert out.endswith("2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0\n");

--- a/docs/source/examples/test_small_array_int.py
+++ b/docs/source/examples/test_small_array_int.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import numpy as np
+
+import pytest
+
+from pych.extern import Chapel
+
+@Chapel()
+def printArray(arr=np.ndarray):
+    """
+    writeln(arr);
+    """
+    return None
+
+if __name__ == "__main__":
+    arr = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    print arr
+    printArray(arr);
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+@pytest.mark.xfail
+def test_small_array():
+    out = testcase.runpy(os.path.realpath(__file__))
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created. The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run) But that means
+    # we can't use ==
+    assert out.endswith("1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0");

--- a/docs/source/examples/test_small_array_reals.py
+++ b/docs/source/examples/test_small_array_reals.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+import numpy as np
+
+from pych.extern import Chapel
+
+@Chapel()
+def printArray(arr=np.ndarray):
+    """
+    writeln(arr);
+    """
+    return None
+
+if __name__ == "__main__":
+    arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    print arr
+    printArray(arr);
+
+import testcase
+# contains the general testing method, which allows us to gather output
+import os.path
+
+def test_small_array_reals():
+    out = testcase.runpy(os.path.realpath(__file__))
+    # The first time this test is run, it may contain output notifying that
+    # a temporary file has been created. The important part is that this
+    # expected output follows it (enabling the test to work for all runs, as
+    # the temporary file message won't occur in the second run) But that means
+    # we can't use ==
+    assert out.endswith("1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0\n");

--- a/docs/source/examples/test_sparse_array_error_msg.py
+++ b/docs/source/examples/test_sparse_array_error_msg.py
@@ -110,4 +110,4 @@ def test_example():
     )
     # Verifies that we get the expected error message when we are passed a
     # numpy array that is not densely packed
-    assert out.endswith('error: halt reached - pyChapel does not support sparsely packed ndarrays\n')
+    assert 'warning: pyChapel may not support unusually strided ndarrays\n' in out

--- a/docs/source/examples/test_sparse_array_error_msg.py
+++ b/docs/source/examples/test_sparse_array_error_msg.py
@@ -10,8 +10,6 @@ import matplotlib.ticker as mticker
 import matplotlib.dates as mdates
 import numpy as np
 
-import pytest
-
 from pych.extern import Chapel
 
 elapsed = [time.time()]
@@ -103,7 +101,6 @@ import testcase
 # contains the general testing method, which allows us to gather output
 import os
 
-@pytest.mark.xfail
 def test_example():
     filename = os.sep.join([
         os.path.dirname(os.path.realpath(__file__)), "aux", "GBPUSD1m.txt"
@@ -111,4 +108,6 @@ def test_example():
     out = testcase.runpy(
         os.path.realpath(__file__) + ' --filename %s --no-viz' % filename
     )
-    assert out.endswith('171.26344695\n')
+    # Verifies that we get the expected error message when we are passed a
+    # numpy array that is not densely packed
+    assert out.endswith('error: halt reached - pyChapel does not support sparsely packed ndarrays\n')

--- a/module/ext/src/extern.chpl
+++ b/module/ext/src/extern.chpl
@@ -16,7 +16,7 @@ module Pythonic {
     }
 
     proc pych_to_chpl(arr: pych_array) {
-
+        pragma "no auto destroy"
         var dom = {0..1, 0..4};
         var stride = (1, 1);
         var block = (5, 1);
@@ -29,6 +29,7 @@ module Pythonic {
             dom = dom._value,               // The underlying class implementation
             noinit_data = true              // Prevent overwriting your data
         );     
+        dom._value.add_arr(ret);
 
         // rank*int tuples
 

--- a/module/ext/src/ptrToArray.chpl
+++ b/module/ext/src/ptrToArray.chpl
@@ -35,6 +35,7 @@ proc convert(ref foo : _ddata(int), d, stride: d.rank*int, block: d.rank*int) {
       dom=d._value,          // d._value is the underlying class implementation
       noinit_data=true);     // prevent overwriting your data
 
+  d._value.add_arr(ret);
   // rank*int tuples
 
   // stride for each dimension

--- a/module/templates/chapel/convert.pych.1d.chpl
+++ b/module/templates/chapel/convert.pych.1d.chpl
@@ -1,2 +1,2 @@
 var %(aname)s__defaultRect = pych_to_chpl1D(%(aname)s_pych);
-var %(aname)s => _getArray(%(aname)s__defaultRect);
+ref %(aname)s = _getArray(%(aname)s__defaultRect);

--- a/module/templates/chapel/prefix.chpl
+++ b/module/templates/chapel/prefix.chpl
@@ -84,10 +84,10 @@ proc pych_to_chpl1D(arr: pych_array) {
     for i in 1..arr.nd {
         // TODO: Is this conversion from bytes to elements correct?
         // The block seems to be what NumPy call strides.
-      if (arr.strides(i):int(64) != arr.itemsize) then
-        halt("pyChapel does not support sparsely packed ndarrays");
-      ret.blk(i) = 1;
-        //ret.blk(i) = (arr.strides(i):int(64) / arr.itemsize);
+      if (arr.strides(i):int(64) != arr.itemsize) {
+        writeln("warning: pyChapel may not support unusually strided ndarrays");
+      }
+      ret.blk(i) = (arr.strides(i):int(64) / arr.itemsize);
     }
     //ret.blk = block;
 

--- a/module/templates/chapel/prefix.chpl
+++ b/module/templates/chapel/prefix.chpl
@@ -55,6 +55,7 @@ proc rangify(shape) where isTuple(shape) {
 }
 
 proc pych_to_chpl1D(arr: pych_array) {
+    pragma "no auto destroy"
     var dom = {0..(arr.shape(1):int(64)-1)};
 
     var stride = (1,);
@@ -101,7 +102,7 @@ proc pych_to_chpl1D(arr: pych_array) {
 }
 
 proc pych_to_chpl2D(arr: pych_array) {
-
+    pragma "no auto destroy"
     var dom = {(...rangify(arr.shape))};
 
     //writeln(pych_to_chplT(arr));

--- a/module/templates/chapel/prefix.chpl
+++ b/module/templates/chapel/prefix.chpl
@@ -84,7 +84,10 @@ proc pych_to_chpl1D(arr: pych_array) {
     for i in 1..arr.nd {
         // TODO: Is this conversion from bytes to elements correct?
         // The block seems to be what NumPy call strides.
-        ret.blk(i) = (arr.strides(i):int(64) / arr.itemsize);
+      if (arr.strides(i):int(64) != arr.itemsize) then
+        halt("pyChapel does not support sparsely packed ndarrays");
+      ret.blk(i) = 1;
+        //ret.blk(i) = (arr.strides(i):int(64) / arr.itemsize);
     }
     //ret.blk = block;
 


### PR DESCRIPTION
When [the array views branch](https://github.com/chapel-lang/chapel/pull/5338)
was merged into the Chapel implementation, we started experiencing a failure
with test_finance_chapel_numpy.py.  This commit will quiet the pyChapel nightly
testing.  It also makes some other improvements along the way.

The issue was that the array views implementation removed the need for the
blk field on DefaultRectangular arrays, but the pyChapel support of passing
numpy arrays to Chapel relied on this field being present.  Numpy arrays can
be sparsely packed under certain circumstances, which were exercised by the
test in question: loading a file to create multiple arrays at once.  The arrays
themselves knew that they only referred to one column, but the data was not
separated when creating these arrays, merely strided.

Work will need to be done to allow Chapel to understand that information again,
but for now, I have added a warning to the translation of a numpy array to a Chapel
one if the strides are not equal to the item size, and made a copy of the test
which will pass again, by calling .flatten() on the numpy arrays created, as well
as a copy to verify that the warning still fires appropriately.

Due to the deprecation of the alias operator `=>` in
[the relevant Chapel merge](https://github.com/chapel-lang/chapel/pull/5752), I
also needed to replace the use of the alias operator with a ref assignment for
everything to work.

As a bonus, I added some "no auto destroy" pragmas as appropriate for domains
that would otherwise not outlive their scope, and mirrored a change that had been
made earlier from the array implementation to the ext/src files.  I also added six
new array tests for basic functionality.  These tests verify:
- the behavior when passing in an array of reals and modifying that array
- the behavior when passing in an array of reals and making a local copy of
  that array, which is then modified
- the behavior when passing in two arrays of reals and using both of them to
  create a new local array
- the behavior when returning an array of reals (which isn't currently
  supported)
- the behavior when creating an array of integers (which also isn't currently
  supported)
- the behavior when passing in an array of reals and writing it as is.

Thanks to Brad and Ben H for the insights