### PR TITLE
Update line numbers

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -70,7 +70,7 @@ following content:
 
 .. literalinclude:: /examples/test_chapel_inline.py
    :language: python
-   :lines: 1-12
+   :lines: 1-11
 
 Then try running it::
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -27,7 +27,7 @@ conventions.
 
 .. literalinclude:: /examples/test_chapel_inline.py
    :language: python
-   :lines: 1-12
+   :lines: 1-11
 
 The Chapel code goes into the ``docstring`` of the decorated function.
 
@@ -52,7 +52,7 @@ function-body is taken from the given file.
 
 .. literalinclude:: /examples/test_bfile.py
    :language: python
-   :lines: 1-9
+   :lines: 1-8
 
 The ``bfile`` target could contain something like below.
 
@@ -94,7 +94,7 @@ with a function body.  For example,
 
 .. literalinclude:: /examples/test_chapel_sfile2.py
    :language: python
-   :lines: 1-9
+   :lines: 1-8
 
 Where ``sfile.hello.chpl`` contains:
 
@@ -130,7 +130,7 @@ function:
 
 .. literalinclude:: /examples/test_sfile_hellolib.py
    :language: python
-   :lines: 1-9
+   :lines: 1-8
 
 Let's say that you insist on calling your ``@Chapel`` decorated Python function
 ``hello_world`` and you refuse to rename, nor export the Chapel procedure under
@@ -138,7 +138,7 @@ a different name, then you can map the Python function using ``ename``:
 
 .. literalinclude:: /examples/test_sfile_ename.py
    :language: python
-   :lines: 1-9
+   :lines: 1-8
 
 Real-world cases usually involve motivation other than stubborn unwillingness to
 refactor code. Regardless of the motivation, the ``ename`` decorator argument

--- a/docs/source/usage_examples.rst
+++ b/docs/source/usage_examples.rst
@@ -26,7 +26,7 @@ An example of such an application is provided below:
 .. literalinclude:: /examples/test_finance_python_numpy.py
    :language: python
    :linenos:
-   :lines: 1-92
+   :lines: 1-96
 
 Where the computationally intensive part is the function
 ``quant``. Do note that the specific implementatio of the ``quant`` function
@@ -35,19 +35,19 @@ Using ``pych`` this function can be mapped to Chapel by changing:
 
 .. literalinclude:: /examples/test_finance_python_numpy.py
    :language: python
-   :lines: 58-67
+   :lines: 62-71
 
 to:
 
 .. literalinclude:: /examples/test_finance_chapel_numpy.py
    :language: python
-   :lines: 60-72
+   :lines: 63-75
 
 and adding the include statement:
 
 .. literalinclude:: /examples/test_finance_chapel_numpy.py
    :language: python
-   :lines: 12-12
+   :lines: 15-15
 
 These two implementations can be executed by the commands::
 
@@ -87,7 +87,7 @@ An example of such an application is provided below:
 .. literalinclude:: /examples/test_python_synthetic_numpy.py
    :language: python
    :linenos:
-   :lines: 1-47
+   :lines: 1-50
 
 where the time-consuming, computational expensive, and memory hungry portion of
 the application is the data-processing performed in the `simulation` function.


### PR DESCRIPTION
Some of the :lines: numbers of the .py scripts included in
usage_examples.rst were out of date.  Update them.

Many of the :lines: lines in introduction.rst and usage.rst included
an extra blank line at the end.  Remove them.
