### PR TITLE
Force testing script to grab the latest version of pytest

### DIFF
--- a/util/test_python.bash
+++ b/util/test_python.bash
@@ -23,7 +23,7 @@ source util/quickstart/setchplenv.bash && \
 
 # Install python dependencies for running the tests (not building the docs).
 log_info "Installing python test dependencies."
-pip install -r $TST_DIR/requirements.txt
+pip install -r $TST_DIR/requirements.txt --upgrade
 
 (
     log_info "Moving to: ${MODULE_DIR}"


### PR DESCRIPTION
The Travis build started failing because it had an older version of pytest and
our installation of the requirements file didn't force it to get the latest
version of the package.  Force the installation to upgrade any packages it
installs in that step.