### PR TITLE
Update expected error message for this test

### DIFF
--- a/docs/source/examples/test_no_depends_fails.py
+++ b/docs/source/examples/test_no_depends_fails.py
@@ -16,4 +16,4 @@ def test_using_multiple_modules():
     out = testcase.runpy(os.path.realpath(__file__))
     # Ensure that when a used module is nowhere near the exported function, we
     # get an error message to that effect.
-    assert "error: Cannot find module or enum \'M1\'" in out
+    assert "error: Cannot find module or enum" in out


### PR DESCRIPTION
PR 6370 on the chapel repository caused a change to the error message output
when a Chapel module or enum can't be found in a use statement, resulting in
the failure of this test to match expected output.  Update accordingly.