### PR TITLE
Remove pip version constraints and -lgmp dependency. Add Python<3.0 requirement.

### DIFF
--- a/module/configs/pych.json
+++ b/module/configs/pych.json
@@ -86,8 +86,7 @@
             ],
             "lflags": [
                 "-shared",
-                "-lpthread",
-                "-lgmp"
+                "-lpthread"
             ],
 
             "ctargets": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python<3.0
 pybtex
 Pygments
 Sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-pybtex==0.20.1
-Pygments>=2.0,<3
-Sphinx==1.3.6
-sphinx_rtd_theme==0.1.9
-sphinxcontrib-bibtex==0.3.3
-numpy==1.11.0
-matplotlib==1.5.1
+pybtex
+Pygments
+Sphinx
+sphinx_rtd_theme
+sphinxcontrib-bibtex
+numpy
+matplotlib
 
 future>=0.15.2


### PR DESCRIPTION
Fixes pychapel build on Ubuntu 16.04 and SLES 12.2