### PR TITLE
Remove "Usage Other" from docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,7 +91,7 @@ release = u"%s" % APP_VERSION
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['usage_other']
+exclude_patterns = ['usage_other.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,7 +91,7 @@ release = u"%s" % APP_VERSION
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ['usage_other']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,6 @@ Contents:
    introduction.rst
    usage.rst
    usage_examples.rst
-   usage_other.rst
    configuration.rst
    pych/index.rst
 


### PR DESCRIPTION
Remove [usage other](http://pychapel.readthedocs.io/usage_other.html) section from docs until it's more fleshed out and better supported.

Kind of resolves #79