### PR TITLE
Add "pip install setuptools_scm" to test script, avoid fatal error

### DIFF
--- a/util/test_python.bash
+++ b/util/test_python.bash
@@ -23,6 +23,12 @@ source util/quickstart/setchplenv.bash && \
 
 # Install python dependencies for running the tests (not building the docs).
 log_info "Installing python test dependencies."
+
+# 2017-08-21:   This "pip install setuptools_scm" avoids some kind of bug in pip
+#     See reference: https://github.com/pypa/pypi-legacy/issues/322
+#   search for text: I did pip install setuptools_scm and it solved the problem.
+pip install setuptools_scm
+
 pip install -r $TST_DIR/requirements.txt --upgrade
 
 (


### PR DESCRIPTION
This change fixes the build failure "[SSL: CERTIFICATE_VERIFY_FAILED]"
when pip tries to download setuptools_scm to satisfy a dependency of
pytest-xdist-1.20.0, which happened consitently on various Cray internal
SLES build slaves since Aug 09 (except on chap05, where the error
never happened)

Suggested by: https://github.com/pypa/pypi-legacy/issues/322,
  search for: "I did pip install setuptools_scm and it solved the problem"