### PR TITLE
Fix trivial unit test error that started when numpy version changed

### DIFF
--- a/docs/source/examples/test_modify_array_argument_reals.py
+++ b/docs/source/examples/test_modify_array_argument_reals.py
@@ -28,4 +28,4 @@ def test_modify_array_argument_reals():
     # expected output follows it (enabling the test to work for all runs, as
     # the temporary file message won't occur in the second run) But that means
     # we can't use ==
-    assert out.endswith("[  2.   3.   4.   5.   6.   7.   8.   9.  10.  11.]\n");
+    assert out.endswith("[ 2.  3.  4.  5.  6.  7.  8.  9. 10. 11.]\n");


### PR DESCRIPTION
The version of numpy brought in by pip changed, which changed some
test outputs in meaningless ways (ie, spaces), and
those meaningless changes broke a unit test with
    assertEquals( "string literal", test(something) )

This change fixes the unit test error, without at all addressing
the underlying issue (hyper-sensitive string comparison).