### PR TITLE
pychapel 0.1.18: Fix lib path for Chapel > 1.16.0; pip installer; docs.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,7 +67,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u"%s" % APP_NAME
-copyright = u'2014-2016, Cray Inc.'
+copyright = u'2014-2018, Cray Inc.'
 author = 'Simon A. F. Lund'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -5,10 +5,10 @@ pyChapel uses a configuration file to setup the underlying machinary. This file
 is called `pych.json` and is installed with the rest of the pyChapel package.
 Which means it should be available in a location such as::
 
+  $HOME/.local/share/pych/config/pych.json
   /usr/local/share/pych/config/pych.json
-  /usr/share/pych/config/pych.json
 
-Or in some other location if the `--prefix` flag is used when installing
+Or in some other location if a Python virtualenv is used when installing
 pyChapel.  The configuration-file defines locations of resources, behaviour of
 pyChapel and where output-files such as `.so` objects are stored and loaded
 from.

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -47,7 +47,7 @@ Run the pyChapel self-check. Note the "Missing Chapel lib" dir location::
 PyChapel requires the Chapel compiler and runtime, which must be built from source
 to work with pyChapel. 
 
-Get Chapel source from Github::
+Get the Chapel source from Github::
 
   $ cd $HOME    # For example- any location that will not get accidentally deleted
   $ git clone git@github.com:chapel-lang/chapel.git
@@ -81,7 +81,7 @@ Build the Chapel compiler and run-time system::
   $ make
 
 See `Quickstart <https://chapel-lang.org/docs/latest/usingchapel/QUICKSTART.html>`_ for more
-about building Chapel.
+information about building Chapel.
 
 
 Chapel run-time libraries
@@ -90,8 +90,8 @@ Chapel run-time libraries
 The Chapel build leaves the run-time libraries in a platform-dependent internal subdirectory.
 Fortunately, a utility is provided that returns the location.
 The library files must be copied into pyChapel's "Chapel lib" internal subdirectory: the
-"Missing Chapel lib" dir location reported by ``pych -k``.  For example,
-``$HOME/.local/share/pych/lib``).
+"Missing Chapel lib" dir location reported by ``pych -k``
+(for example, ``$HOME/.local/share/pych/lib``).
 
 Copy the run-time libraries from Chapel into pyChapel::
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -1,3 +1,4 @@
+
 .. _sec-getting-started:
 
 Getting Started
@@ -7,60 +8,108 @@ This section covers installation of pyChapel and required software packages,
 introduces the "pych" utility and provides a "hello world" example of using
 pyChapel.
 
+System Requirements
+~~~~~~~~~~~~~~~~~~~
+
+* Linux-64 host system (Ubuntu 16.04 is shown here). Mac OS-X is not yet supported.
+* Python-2.7 (the later, the better), with pip. Python-3 is not yet supported.
+* Support for Chapel "Quickstart" on the host. See `Prerequisites <https://chapel-lang.org/docs/latest/usingchapel/prereqs.html>`_
+
 Installation
 ~~~~~~~~~~~~
 
-The steps for installing pyChapel and the software packages it depends upon is
-fairly straightforward. The following provides a setup guide on a Ubuntu-linux system.
+The steps for installing pyChapel and the software packages it depends upon are
+fairly straightforward. The following provides a setup guide on a Ubuntu-16.04
+host system.
 
-Depending on your system the commands might be slightly different but the 
-should provide the gist of what is required.
+The pyChapel Python module itself is available from PyPi.
+Make sure you are using the Python2 version of Pip and any other Python utilities.
+We recommend using Pip's "user install" option as shown here, but those familiar
+with other Python2 virtual environments may adapt these instructions accordingly.
+A Pip "user install" will install pyChapel under ``$HOME/.local``, so make sure that
+``$HOME/.local/bin`` is near the front of your PATH.
 
-pyChapel depends on the pyChapel Python module itself which is available via
-PyPi. Additionally the Chapel compiler and a library compiled with the compiler
-is required.
+Install pyChapel and dependencies from PyPi::
 
-Installing pyChapel::
+  $ pip install --user "numpy>=1.14" "future>=0.15.2" pyChapel
 
-  pip install numpy argparse pyChapel
+Run the pyChapel self-check. Note the "Missing Chapel lib" dir location::
 
-Build and install Chapel from source::
+  $ pych -k     # if "command not found", make sure $HOME/.local/bin is in PATH
+    Checking installation...
+    * Templates
+    * Object Storage
+    * Libraries
+    ERR: Missing Chapel lib file(libchpl.a) in dir(/home/chapeluser/.local/share/pych/lib)
+    ERR: Missing Chapel lib file(main.o) in dir(/home/chapeluser/.local/share/pych/lib)
+    * Commands
 
-  cd ~
-  git clone git@github.com:chapel-lang/chapel.git
+PyChapel requires the Chapel compiler and runtime, which must be built from source
+to work with pyChapel. 
 
-Add this or equivalent to your environment::
+Get Chapel source from Github::
 
-  #
-  # Setup Chapel
-  #
-  CWD=`pwd`
-  export CHPL_REGEXP=none
-  export CHPL_MEM=cstdlib
-  export CHPL_GMP=none
-  export CHPL_TASKS=fifo
-  export CHPL_LIBMODE=shared
-  cd ~/chapel/ && source ~/chapel/util/setchplenv.bash
-  cd $CWD
+  $ cd $HOME    # For example- any location that will not get accidentally deleted
+  $ git clone git@github.com:chapel-lang/chapel.git
 
-Reload your environment, then build the compiler::
+Note the location::
 
-  cd ~/chapel
-  make
+    $HOME/chapel  (in this example)
 
-After building the two files: "libchpl.a" and "main.o" library should be available here::
+Add the following to your shell environment::
 
-  ~/chapel/lib/linux64/gnu/arch-native/loc-flat/comm-none/tasks-fifo/tmr-generic/mem-cstdlib/atomics-intrinsics/gmp-none/hwloc-none/re-none/wide-struct/fs-none/
+    (.bashrc, for example)
 
-Copy these to the "lib" library of pyChapel. Using a default install this can be
-done with the command::
+    #
+    # Setup Chapel environment
+    #
+    # CHPL_HOME=Chapel source location
+    #
+    export CHPL_HOME=$HOME/chapel   # in this example
+    export CHPL_LIBMODE=shared
+    source $CHPL_HOME/util/quickstart/setchplenv.bash
+    #
+    # Add Pip/Python "user install" bin to PATH, if needed
+    #
+    export PATH=$HOME/.local/bin:$PATH
 
-  find ~/chapel/lib/ -depth -type f -exec bash -c 'cp $0 /usr/local/share/pych/lib/' {} \;
+Build the Chapel compiler and run-time system::
 
-After going through these steps the installation can be verified by running the
-"pych" command::
+    (Make sure the above shell environment has been set up first.)
 
-  pych --check
+  $ cd $CHPL_HOME
+  $ make
+
+See `Quickstart <https://chapel-lang.org/docs/latest/usingchapel/QUICKSTART.html>`_ for more
+about building Chapel.
+
+
+Chapel run-time libraries
+-------------------------
+
+The Chapel build leaves the run-time libraries in a platform-dependent internal subdirectory.
+Fortunately, a utility is provided that returns the location.
+The library files must be copied into pyChapel's "Chapel lib" internal subdirectory: the
+"Missing Chapel lib" dir location reported by ``pych -k``.  For example,
+``$HOME/.local/share/pych/lib``).
+
+Copy the run-time libraries from Chapel into pyChapel::
+
+  $ libchpl=`$CHPL_HOME/util/config/compileline --main.o`
+  $ libpych=$HOME/.local/share/pych/lib     # from "pych -k"
+  $ cp `dirname $libchpl`/* $libpych
+
+Re-run the pyChapel self-check::
+
+  $ pych -k
+    Checking installation...
+    * Templates
+    * Object Storage
+    * Libraries
+    * Commands
+
+  # no "Missing Chapel lib files"
+
 
 Hello World
 ~~~~~~~~~~~
@@ -74,7 +123,7 @@ following content:
 
 Then try running it::
 
-  python hw.py
+  $ python hw.py
 
 This should then print out the classic::
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -29,13 +29,22 @@ with other Python2 virtual environments may adapt these instructions accordingly
 A Pip "user install" will install pyChapel under ``$HOME/.local``, so make sure that
 ``$HOME/.local/bin`` is near the front of your PATH.
 
+If Pip is not already installed on your system, but easy_install is, you can probably
+"user install" your own copy of Pip::
+
+    easy_install --prefix $HOME/.local pip
+
 Install pyChapel and dependencies from PyPi::
 
-  $ pip install --user "numpy>=1.14" "future>=0.15.2" pyChapel
+    pip install --user "numpy>=1.14" "future>=0.15.2"
+    pip install --user --upgrade --no-binary pyChapel pyChapel
 
-Run the pyChapel self-check. Note the "Missing Chapel lib" dir location::
+Run the pyChapel self-check::
 
-  $ pych -k     # if "command not found", make sure $HOME/.local/bin is in PATH
+    pych -k     # if "command not found", make sure $HOME/.local/bin is in PATH
+
+Note the `Missing Chapel lib` dir location in the output::
+
     Checking installation...
     * Templates
     * Object Storage
@@ -49,16 +58,14 @@ to work with pyChapel.
 
 Get the Chapel source from Github::
 
-  $ cd $HOME    # For example- any location that will not get accidentally deleted
-  $ git clone git@github.com:chapel-lang/chapel.git
+    cd $HOME    # For example- any location that will not get accidentally deleted
+    git clone git@github.com:chapel-lang/chapel.git
 
 Note the location::
 
-    $HOME/chapel  (in this example)
+    $HOME/chapel    # in this example
 
-Add the following to your shell environment::
-
-    (.bashrc, for example)
+Add the following to your shell environment (`.bashrc`, for example)::
 
     #
     # Setup Chapel environment
@@ -75,10 +82,10 @@ Add the following to your shell environment::
 
 Build the Chapel compiler and run-time system::
 
-    (Make sure the above shell environment has been set up first.)
+    # Make sure the above shell environment has been set up first
 
-  $ cd $CHPL_HOME
-  $ make
+    cd $CHPL_HOME
+    make
 
 See `Quickstart <https://chapel-lang.org/docs/latest/usingchapel/QUICKSTART.html>`_ for more
 information about building Chapel.
@@ -89,26 +96,27 @@ Chapel run-time libraries
 
 The Chapel build leaves the run-time libraries in a platform-dependent internal subdirectory.
 Fortunately, a utility is provided that returns the location.
-The library files must be copied into pyChapel's "Chapel lib" internal subdirectory: the
-"Missing Chapel lib" dir location reported by ``pych -k``
+The library files must be copied into pyChapel's internal "lib" subdirectory: the
+`Missing Chapel lib` dir location reported by ``pych -k``
 (for example, ``$HOME/.local/share/pych/lib``).
 
 Copy the run-time libraries from Chapel into pyChapel::
 
-  $ libchpl=`$CHPL_HOME/util/config/compileline --main.o`
-  $ libpych=$HOME/.local/share/pych/lib     # from "pych -k"
-  $ cp `dirname $libchpl`/* $libpych
+    libchpl=`$CHPL_HOME/util/config/compileline --main.o`
+    libpych=$HOME/.local/share/pych/lib     # from "pych -k"
+    cp `dirname $libchpl`/* $libpych
 
 Re-run the pyChapel self-check::
 
-  $ pych -k
+    pych -k
+
+Note: no `Missing Chapel lib files` in the output::
+
     Checking installation...
     * Templates
     * Object Storage
     * Libraries
     * Commands
-
-  # no "Missing Chapel lib files"
 
 
 Hello World
@@ -123,7 +131,7 @@ following content:
 
 Then try running it::
 
-  $ python hw.py
+    python hw.py
 
 This should then print out the classic::
 

--- a/docs/source/pych/notes.rst
+++ b/docs/source/pych/notes.rst
@@ -1,5 +1,5 @@
-Miscelanous Notes
-=================
+Miscellanous Notes
+==================
 
 Developer Notes
 ~~~~~~~~~~~~~~~

--- a/docs/source/pych/notes.rst
+++ b/docs/source/pych/notes.rst
@@ -1,5 +1,5 @@
-Miscellanous Notes
-==================
+Miscellaneous Notes
+===================
 
 Developer Notes
 ~~~~~~~~~~~~~~~

--- a/module/README.txt
+++ b/module/README.txt
@@ -1,0 +1,20 @@
+pyChapel: The Python/Chapel integration module
+
+pyChapel provides interoperability with Chapel in three forms:
+* Chapel code inlined in Python
+* Chapel code from source-files
+* Compile Chapel modules into Python modules
+
+      Source:  https://github.com/chapel-lang/pychapel
+        Docs:  http://pychapel.readthedocs.io
+      Author:  Simon A. F. Lund
+ Maintainers:  Chapel Developers
+
+      Chapel:  http://www.chapel-lang.org
+       Email:  chapel_info@cray.com
+
+     Licence:  The Apache License, Version 2.0
+               http://www.apache.org/licenses/LICENSE-2.0
+
+Copyright 2014-2018, Cray Inc.
+Other additional copyright holders may be indicated within.

--- a/module/pych/version.py
+++ b/module/pych/version.py
@@ -2,4 +2,4 @@
     A container for pyChapel name and version.
 """
 APP_NAME = 'pyChapel'
-APP_VERSION = '0.1.17'
+APP_VERSION = '0.1.18'

--- a/module/scripts/pych
+++ b/module/scripts/pych
@@ -60,9 +60,19 @@ def check(arg):
 
     # Check that Chapel libraries are there
     info(" * Libraries")
+    dir = os.sep.join([
+        CONFIG["compilers"]["chapel"]["root_path"],
+        CONFIG["compilers"]["chapel"]["lib_path"],
+    ])
+    if not os.path.exists(dir):
+        error( "Missing lib dir at (%s)" % (dir) )
+    else:
+        for file in ["libchpl.a", "main.o",]:   # FIXME: hard-coded in config/pych.json
+            if not os.path.exists(os.sep.join([dir, file,])):
+                error( "Missing Chapel lib file(%s) in dir(%s)" % (file, dir))
 
     # Check that c-headers are there
-    info(" * Headers")
+    # info(" * Headers")    # FIXME: should check for header files here
 
     # Check that the commands are invokable
     info(" * Commands")
@@ -141,7 +151,7 @@ def testing(arg):
     for path in CONFIG._config["testing"]["paths"]:
         info("Running tests in %s" % path)
         process = subprocess.Popen(
-            ["py.test", path]
+            ["py.test", "-v", path]
         )
         out, err = process.communicate()
         retvals.append(process.returncode)

--- a/module/setup.py
+++ b/module/setup.py
@@ -39,10 +39,13 @@ class post_install(install_data):
 setup(
     name        = APP_NAME,
     version     = APP_VERSION,
-    description = 'pyChapel, Python ~ Chapel integration.',
-    url         = 'http://www.bh107.org',
+    description = 'pyChapel: The Python/Chapel integration module',
+    url         = 'http://pychapel.readthedocs.io/',
     author      = 'Simon A. F. Lund',
     author_email='safl@safl.dk',
+    maintainer  = 'Chapel Developers',
+    maintainer_email = 'chapel_info@cray.com',
+    license     = 'Apache 2.0',
     data_files  = [
         ('share/pych/config', ['configs/pych.json']),
         

--- a/util/test_python.bash
+++ b/util/test_python.bash
@@ -42,8 +42,14 @@ pip install -r $TST_DIR/requirements.txt --upgrade
 log_info "Running pych --check"
 pych --check
 
-# Copying pyChapel libchpl dependencies
-find $CHPL_HOME/lib/ -depth -type f -exec bash -c 'cp $0  $VIRTUAL_ENV/share/pych/lib/' {} \;
+log_info "Copying pyChapel libchpl dependencies"
+if libchpl=$( $CHPL_HOME/util/config/compileline --main.o ); then
+    cp $( dirname $libchpl )/* $VIRTUAL_ENV/share/pych/lib/
+    ls -ld $VIRTUAL_ENV/share/pych/lib/*
+else
+    log_error "Failed util/config/compileline --main.o"
+    exit 2
+fi
 
 log_info "Moving to: ${REPO_ROOT}"
 cd $REPO_ROOT


### PR DESCRIPTION
Makes the pip install (w manual Chapel build) work on Linux again, without addressing everything else to be desired. 
This should at least get pychapel back the functionality it had, before 
* Chapel changed its internal runtime lib path
* The last two pypi releases, which were incomplete ("pych.json not found")