### PR TITLE
Constrain matplotlib<2.2.0 in "requirements.txt"

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -10,7 +10,7 @@ Sphinx
 sphinx_rtd_theme
 sphinxcontrib-bibtex
 numpy>=1.14
-matplotlib
+matplotlib<2.2.0
 
 future>=0.15.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ Sphinx
 sphinx_rtd_theme
 sphinxcontrib-bibtex
 numpy>=1.14
-matplotlib
+matplotlib<2.2.0
 
 future>=0.15.2


### PR DESCRIPTION
Issue #95 : workaround fixes unit test failures by avoiding the
newest matplotlib/2.2.0 version, which now requires python bz2
module, which we do not have on our test system.
pychapel itself does not need bz2.